### PR TITLE
WIP: Migrate to newer version of Plutus API

### DIFF
--- a/NFTSeries/nftSeries.hs
+++ b/NFTSeries/nftSeries.hs
@@ -18,9 +18,11 @@ import           Data.Map             as Map
 import qualified Ledger.Ada            as Ada
 import           Data.Void              (Void)
 import           Plutus.Contract        as Contract
+import           Plutus.V1.Ledger.Address
 import           Ledger.Constraints.TxConstraints
-import           Ledger.Tx           hiding (Mint, mint)
+import           Ledger.Tx
 import           Plutus.ChainIndex.Tx
+import           Control.Lens 
 
 data ValidatorData = ValidatorData {vdOwner :: !PaymentPubKeyHash, vdMaxSupply :: !Integer, vdThreadSymbol :: !CurrencySymbol}
 
@@ -34,7 +36,7 @@ data Action = Mint | Burn
 -- the policy script that actually represents the NFT policy
 mkTokenPolicy :: TokenData -> Action -> ScriptContext -> Bool
 mkTokenPolicy tokenData action ctx = case action of
-    Mint -> checkMint
+    Main.Mint -> checkMint
     Burn -> checkBurn
     where
         checkMint :: Bool
@@ -76,7 +78,7 @@ mkTokenPolicy tokenData action ctx = case action of
 -- the policy that mints a single token in order to initialize the state machine of the validator (thread token)
 mkThreadPolicy :: ThreadData -> Action -> ScriptContext -> Bool
 mkThreadPolicy threadData action ctx = case action of
-    Mint -> hasUtxo && checkMint 1
+    Main.Mint -> hasUtxo && checkMint 1
     Burn -> checkMint (-1)
   where
     txInfo :: TxInfo
@@ -92,10 +94,13 @@ mkThreadPolicy threadData action ctx = case action of
 
 -- the validator script that keeps track of the NFT supply and increments the mint id
 mkTokenValidator :: ValidatorData -> Integer -> Action -> ScriptContext -> Bool
-mkTokenValidator validatorData count action ctx =  isSatisfiable (mustBeSignedBy (vdOwner validatorData)) && case action of
-    Mint -> checkSupply && checkOutput
+mkTokenValidator validatorData count action ctx =  signedByOwner && case action of
+    Main.Mint -> checkSupply && checkOutput
     Burn -> checkBurn
     where
+        signedByOwner:: Bool
+        signedByOwner = txSignedBy (scriptContextTxInfo ctx) $ unPaymentPubKeyHash $ (vdOwner validatorData)
+
         checkSupply :: Bool
         checkSupply = count < vdMaxSupply validatorData || vdMaxSupply validatorData == -1
 
@@ -185,7 +190,7 @@ simulate = endpoint @"simulate" @MintParams $ \(MintParams{..}) -> do
 
         lookups = Constraints.mintingPolicy (threadPolicy threadData) <> 
                 Constraints.unspentOutputs utxos
-        tx = Constraints.mustSpendPubKeyOutput oref <> Constraints.mustMintValueWithRedeemer (Redeemer (PlutusTx.toBuiltinData Mint)) threadValue <> 
+        tx = Constraints.mustSpendPubKeyOutput oref <> Constraints.mustMintValueWithRedeemer (Redeemer (PlutusTx.toBuiltinData Main.Mint)) threadValue <> 
             Constraints.mustPayToOtherScript vh (Datum (PlutusTx.toBuiltinData (0 :: Integer))) threadValue
     void $ submitTxConstraintsWith @TokenValidator lookups tx
 
@@ -204,7 +209,7 @@ simulate = endpoint @"simulate" @MintParams $ \(MintParams{..}) -> do
         lookups = Constraints.typedValidatorLookups (tokenValidatorInstance validatorData) <>
                 Constraints.mintingPolicy (tokenPolicy tokenData) <>
                 Constraints.unspentOutputs simpleutxos
-        tx = collectFromScript simpleutxos Mint <> 
+        tx = collectFromScript simpleutxos Main.Mint <> 
             Constraints.mustMintValue value <> 
             Constraints.mustPayToTheScript (count+1) threadValue
     void $ submitTxConstraintsWith @TokenValidator lookups tx
@@ -224,7 +229,7 @@ simulate = endpoint @"simulate" @MintParams $ \(MintParams{..}) -> do
         lookups = Constraints.typedValidatorLookups (tokenValidatorInstance validatorData) <>
                 Constraints.mintingPolicy (tokenPolicy tokenData) <>
                 Constraints.unspentOutputs simpleutxos
-        tx = collectFromScript simpleutxos Mint <> 
+        tx = collectFromScript simpleutxos Main.Mint <> 
             Constraints.mustMintValue value <> 
             Constraints.mustPayToTheScript (count+1) threadValue
     void $ submitTxConstraintsWith @TokenValidator lookups tx
@@ -244,7 +249,7 @@ simulate = endpoint @"simulate" @MintParams $ \(MintParams{..}) -> do
         lookups = Constraints.typedValidatorLookups (tokenValidatorInstance validatorData) <>
                 Constraints.mintingPolicy (tokenPolicy tokenData) <>
                 Constraints.unspentOutputs simpleutxos
-        tx = collectFromScript simpleutxos Mint <> 
+        tx = collectFromScript simpleutxos Main.Mint <> 
             Constraints.mustMintValue value <> 
             Constraints.mustPayToTheScript (count+2) threadValue
     void $ submitTxConstraintsWith @TokenValidator lookups tx
@@ -302,7 +307,7 @@ PlutusTx.makeLift ''ThreadData
 PlutusTx.makeIsDataIndexed ''ThreadData [('ThreadData,0)]
 
 PlutusTx.makeLift ''Action
-PlutusTx.makeIsDataIndexed ''Action [('Mint,0),('Burn,1)]
+PlutusTx.makeIsDataIndexed ''Action [('Main.Mint,0),('Burn,1)]
 
 
 contract :: AsContractError e => Contract () MintSchema e ()


### PR DESCRIPTION
This pull request tries to address #1 

It currently compiles in the playground, but it does not actually run. I get the following InterpreterError when I try running it:

```
GHC Core to PLC plugin: E042:Error: Unsupported feature: Irreducible type family application: GHC.Types.Any Context: Compiling type: GHC.Types.Any Context: Compiling expr: Ledger.Constraints.TxConstraints.isSatisfiable @ GHC.Types.Any Context: Compiling expr: Ledger.Constraints.TxConstraints.isSatisfiable @ GHC.Types.Any @ GHC.Types.Any Context: Compiling expr: Ledger.Constraints.TxConstraints.isSatisfiable @ GHC.Types.Any @ GHC.Types.Any (Ledger.Constraints.TxConstraints.mustBeSignedBy @ GHC.Types.Any @ GHC.Types.Any (Main.vdOwner validatorData)) Context: Compiling expr: PlutusTx.Bool.&& (Ledger.Constraints.TxConstraints.isSatisfiable @ GHC.Types.Any @ GHC.Types.Any (Ledger.Constraints.TxConstraints.mustBeSignedBy @ GHC.Types.Any @ GHC.Types.Any (Main.vdOwner validatorData))) Context: Compiling expr: PlutusTx.Bool.&& (Ledger.Constraints.TxConstraints.isSatisfiable @ GHC.Types.Any @ GHC.Types.Any (Ledger.Constraints.TxConstraints.mustBeSignedBy @ GHC.Types.Any @ GHC.Types.Any (Main.vdOwner validatorData))) (case action of { Main.Mint -> PlutusTx.Bool.&& (PlutusTx.Bool.|| (PlutusTx.Builtins.lessThanInteger count (Main.vdMaxSupply validatorData)) (PlutusTx.Eq.== @ GHC.Integer.Type.Integer PlutusTx.Eq.$fEqInteger (Main.vdMaxSupply validatorData) (-1))) (let { ds_d15Zm :: (Plutus.V1.Ledger.Value.CurrencySymbol, GHC.Integer.Type.Integer) [LclId, Unf=Unf{Src=<vanilla>, TopLvl=False, Value=False, ConLike=False, WorkFree=False, Expandable=False, Guidance=IF_ARGS [] 298 30}] ds_d15Zm = join { fail_d161x [Occ=Once*!T[1]] :: GHC.Prim.Void# -> (Plutus.V1.Ledger.Value.CurrencySymbol, GHC.Integer.Type.Integer) [LclId[JoinId(1)], Arity=1, Str=<L,U>b, Unf=Unf{Src=<vanilla>, TopLvl=False, Value=True, ConLike=True, WorkFree=True, Expandable=True, Guidance=IF_ARGS [0] 200 0}] fail_d161x _ [Occ=Dead, OS=OneShot] = Control.Exception.Base.patError @ 'GHC.Types.LiftedRep @ (Plutus.V1.Ledger.Value.CurrencySymbol, GHC.Integer.Type.Integer) "/tmp/web-ghc-work-dcc9ed4f1ebc164d/Main.hs:105:27-61|[(cs, _, am)]"# } in case Plutus.V1.Ledger.Value.flattenValue (case ds_d165Y of { (outValue [Occ=Once], _ [Occ=Dead]) -> outValue }) of { [] -> jump fail_d161x GHC.Prim.void#; : ds_d161u [Occ=Once!] ds_d161v [Occ=Once!] -> case ds_d161u of { (cs [Occ=Once], _ [Occ=Dead], am [Occ=Once]) -> case ds_d161v of { [] -> (cs, am); : _ [Occ=Dead] _ [Occ=Dead] -> jump fail_d161x GHC.Prim.void# } } } } in PlutusTx.Bool.&& (PlutusTx.Eq.== @ Plutus.V1.Ledger.Value.CurrencySymbol Plutus.V1.Ledger.Value.$fEqCurrencySymbol0 (case ds_d15Zm of { (cs [Occ=Once], _ [Occ=Dead]) -> cs }) (Main.vdThreadSymbol validatorData)) (PlutusTx.Bool.&& (PlutusTx.Eq.== @ GHC.Integer.Type.Integer PlutusTx.Eq.$fEqInteger (case ds_d15Zm of { (_ [Occ=Dead], am [Occ=Once]) -> am }) 1) (PlutusTx.Eq.== @ GHC.Integer.Type.Integer PlutusTx.Eq.$fEqInteger (case ds_d165Y of { (_ [Occ=Dead], nextCount [Occ=Once]) -> nextCount }) (PlutusTx.Numeric.+ @ GHC.Integer.Type.Integer PlutusTx.Numeric.$fAdditiveSemigroupInteger count (PlutusTx.Foldable.length @ [] @ (Plutus.V1.Ledger.Value.CurrencySymbol, Plutus.V1.Ledger.Value.TokenName, GHC.Integer.Type.Integer) PlutusTx.Foldable.$fFoldable[] (Plutus.V1.Ledger.Value.flattenValue (Plutus.V1.Ledger.Contexts.txInfoMint txInfo))))))); Main.Burn -> let { ds_d161z :: (Plutus.V1.Ledger.Value.CurrencySymbol, GHC.Integer.Type.Integer) [LclId, Unf=Unf{Src=<vanilla>, TopLvl=False, Value=False, ConLike=False, WorkFree=False, Expandable=False, Guidance=IF_ARGS [] 308 30}] ds_d161z = join { fail_d163J [Occ=Once*!T[1]] :: GHC.Prim.Void# -> (Plutus.V1.Ledger.Value.CurrencySymbol, GHC.Integer.Type.Integer) [LclId[JoinId(1)], Arity=1, Str=<L,U>b, Unf=Unf{Src=<vanilla>, TopLvl=False, Value=True, ConLike=True, WorkFree=True, Expandable=True, Guidance=IF_ARGS [0] 200 0}] fail_d163J _ [Occ=Dead, OS=OneShot] = Control.Exception.Base.patError @ 'GHC.Types.LiftedRep @ (Plutus.V1.Ledger.Value.CurrencySymbol, GHC.Integer.Type.Integer) "/tmp/web-ghc-work-dcc9ed4f1ebc164d/Main.hs:108:25-49|[(cs, _, am)]"# } in case Plutus.V1.Ledger.Value.flattenValue (Plutus.V1.Ledger.Contexts.txInfoMint txInfo) of { [] -> jump fail_d163J GHC.Prim.void#; : ds_d163G [Occ=Once!] ds_d163H [Occ=Once!] -> case ds_d163G of { (cs [Occ=Once], _ [Occ=Dead], am [Occ=Once]) -> case ds_d163H of { [] -> (cs, am); : _ [Occ=Dead] _ [Occ=Dead] -> jump fail_d163J GHC.Prim.void# } } } } in PlutusTx.Bool.&& (PlutusTx.Eq.== @ Plutus.V1.Ledger.Value.CurrencySymbol Plutus.V1.Ledger.Value.$fEqCurrencySymbol0 (case ds_d161z of { (cs [Occ=Once], _ [Occ=Dead]) -> cs }) (Main.vdThreadSymbol validatorData)) (PlutusTx.Eq.== @ GHC.Integer.Type.Integer PlutusTx.Eq.$fEqInteger (case ds_d161z of { (_ [Occ=Dead], am [Occ=Once]) -> am }) (-1)) }) Context: Compiling expr: let { ds_d165Y :: (Plutus.V1.Ledger.Value.Value, GHC.Integer.Type.Integer) [LclId, Unf=Unf{Src=<vanilla>, TopLvl=False, Value=False, ConLike=False, WorkFree=False, Expandable=False, Guidance=NEVER}] ds_d165Y = join { fail_d165W [Occ=Once*!T[1]] :: GHC.Prim.Void# -> (Plutus.V1.Ledger.Value.Value, GHC.Integer.Type.Integer) [LclId[JoinId(1)], Arity=1, Str=<L,U>b, Unf=Unf{Src=<vanilla>, TopLvl=False, Value=True, ConLike=True, WorkFree=True, Expandable=True, Guidance=IF_ARGS [0] 200 0}] fail_d165W _ [Occ=Dead, OS=OneShot] = Control.Exception.Base.patError @ 'GHC.Types.LiftedRep @ (Plutus.V1.Ledger.Value.Value, GHC.Integer.Type.Integer) "/tmp/web-ghc-work-dcc9ed4f1ebc164d/Main.hs:(118,33)-(122,51)|case"# } in case Plutus.V1.Ledger.Contexts.getContinuingOutputs ctx of { [] -> jump fail_d165W GHC.Prim.void#; : o ds_d165V [Occ=Once!] -> case ds_d165V of { [] -> case Plutus.V1.Ledger.Tx.txOutDatum o of { GHC.Maybe.Nothing -> Control.Exception.Base.patError @ 'GHC.Types.LiftedRep @ (Plutus.V1.Ledger.Value.Value, GHC.Integer.Type.Integer) "/tmp/web-ghc-work-dcc9ed4f1ebc164d/Main.hs:(119,20)-(122,51)|case"#; GHC.Maybe.Just h [Occ=Once] -> case Plutus.V1.Ledger.Contexts.findDatum h txInfo of { GHC.Maybe.Nothing -> Control.Exception.Base.patError @ 'GHC.Types.LiftedRep @ (Plutus.V1.Ledger.Value.Value, GHC.Integer.Type.Integer) "/tmp/web-ghc-work-dcc9ed4f1ebc164d/Main.hs:(120,27)-(122,51)|case"#; GHC.Maybe.Just ds_d165g [Occ=Once] -> case PlutusTx.IsData.Class.fromBuiltinData @ GHC.Integer.Type.Integer PlutusTx.IsData.Class.$fFromDataInteger (ds_d165g `cast` (Plutus.V1.Ledger.Scripts.N:Datum[0] :: GHC.Types.Coercible Plutus.V1.Ledger.Scripts.Datum PlutusTx.Builtins.Internal.BuiltinData)) of { GHC.Maybe.Nothing -> Control.Exception.Base.patError @ 'GHC.Types.LiftedRep @ (Plutus.V1.Ledger.Value.Value, GHC.Integer.Type.Integer) "/tmp/web-ghc-work-dcc9ed4f1ebc164d/Main.hs:(121,38)-(122,51)|case"#; GHC.Maybe.Just c [Occ=Once] -> (Plutus.V1.Ledger.Tx.txOutValue o, c) } } }; : _ [Occ=Dead] _ [Occ=Dead] -> jump fail_d165W GHC.Prim.void# } } } in PlutusTx.Bool.&& (Ledger.Constraints.TxConstraints.isSatisfiable @ GHC.Types.Any @ GHC.Types.Any (Ledger.Constraints.TxConstraints.mustBeSignedBy @ GHC.Types.Any @ GHC.Types.Any (Main.vdOwner validatorData))) (case action of { Main.Mint -> PlutusTx.Bool.&& (PlutusTx.Bool.|| (PlutusTx.Builtins.lessThanInteger count (Main.vdMaxSupply validatorData)) (PlutusTx.Eq.== @ GHC.Integer.Type.Integer PlutusTx.Eq.$fEqInteger (Main.vdMaxSupply validatorData) (-1))) (let { ds_d15Zm :: (Plutus.V1.Ledger.Value.CurrencySymbol, GHC.Integer.Type.Integer) [LclId, Unf=Unf{Src=<vanilla>, TopLvl=False, Value=False, ConLike=False, WorkFree=False, Expandable=False, Guidance=IF_ARGS [] 298 30}] ds_d15Zm = join { fail_d161x [Occ=Once*!T[1]] :: GHC.Prim.Void# -> (Plutus.V1.Ledger.Value.CurrencySymbol, GHC.Integer.Type.Integer) [LclId[JoinId(1)], Arity=1, Str=<L,U>b, Unf=Unf{Src=<vanilla>, TopLvl=False, Value=True, ConLike=True, WorkFree=True, Expandable=True, Guidance=IF_ARGS [0] 200 0}] fail_d161x _ [Occ=Dead, OS=OneShot] = Control.Exception.Base.patError @ 'GHC.Types.LiftedRep @ (Plutus.V1.Ledger.Value.CurrencySymbol, GHC.Integer.Type.Integer) "/tmp/web-ghc-work-dcc9ed4f1ebc164d/Main.hs:105:27-61|[(cs, _, am)]"# } in case Plutus.V1.Ledger.Value.flattenValue (case ds_d165Y of { (outValue [Occ=Once], _ [Occ=Dead]) -> outValue }) of { [] -> jump fail_d161x GHC.Prim.void#; : ds_d161u [Occ=Once!] ds_d161v [Occ=Once!] -> case ds_d161u of { (cs [Occ=Once], _ [Occ=Dead], am [Occ=Once]) -> case ds_d161v of { [] -> (cs, am); : _ [Occ=Dead] _ [Occ=Dead] -> jump fail_d161x GHC.Prim.void# } } } } in PlutusTx.Bool.&& (PlutusTx.Eq.== @ Plutus.V1.Ledger.Value.CurrencySymbol Plutus.V1.Ledger.Value.$fEqCurrencySymbol0 (case ds_d15Zm of { (cs [Occ=Once], _ [Occ=Dead]) -> cs }) (Main.vdThreadSymbol validatorData)) (PlutusTx.Bool.&& (PlutusTx.Eq.== @ GHC.Integer.Type.Integer PlutusTx.Eq.$fEqInteger (case ds_d15Zm of { (_ [Occ=Dead], am [Occ=Once]) -> am }) 1) (PlutusTx.Eq.== @ GHC.Integer.Type.Integer PlutusTx.Eq.$fEqInteger (case ds_d165Y of { (_ [Occ=Dead], nextCount [Occ=Once]) -> nextCount }) (PlutusTx.Numeric.+ @ GHC.Integer.Type.Integer PlutusTx.Numeric.$fAdditiveSemigroupInteger count (PlutusTx.Foldable.length @ [] @ (Plutus.V1.Ledger.Value.CurrencySymbol, Plutus.V1.Ledger.Value.TokenName, GHC.Integer.Type.Integer) PlutusTx.Foldable.$fFoldable[] (Plutus.V1.Ledger.Value.flattenValue (Plutus.V1.Ledger.Contexts.txInfoMint txInfo))))))); Main.Burn -> let { ds_d161z :: (Plutus.V1.Ledger.Value.CurrencySymbol, GHC.Integer.Type.Integer) [LclId, Unf=Unf{Src=<vanilla>, TopLvl=False, Value=False, ConLike=False, WorkFree=False, Expandable=False, Guidance=IF_ARGS [] 308 30}] ds_d161z = join { fail_d163J [Occ=Once*!T[1]] :: GHC.Prim.Void# -> (Plutus.V1.Ledger.Value.CurrencySymbol, GHC.Integer.Type.Integer) [LclId[JoinId(1)], Arity=1, Str=<L,U>b, Unf=Unf{Src=<vanilla>, TopLvl=False, Value=True, ConLike=True, WorkFree=True, Expandable=True, Guidance=IF_ARGS [0] 200 0}] fail_d163J _ [Occ=Dead, OS=OneShot] = Control.Exception.Base.patError @ 'GHC.Types.LiftedRep @ (Plutus.V1.Ledger.Value.CurrencySymbol, GHC.Integer.Type.Integer) "/tmp/web-ghc-work-dcc9ed4f1ebc164d/Main.hs:108:25-49|[(cs, _, am)]"# } in case Plutus.V1.Ledger.Value.flattenValue (Plutus.V1.Ledger.Contexts.txInfoMint txInfo) of { [] -> jump fail_d163J GHC.Prim.void#; : ds_d163G [Occ=Once!] ds_d163H [Occ=Once!] -> case ds_d163G of { (cs [Occ=Once], _ [Occ=Dead], am [Occ=Once]) -> case ds_d163H of { [] -> (cs, am); : _ [Occ=Dead] _ [Occ=Dead] -> jump fail_d163J GHC.Prim.void# } } } } in PlutusTx.Bool.&& (PlutusTx.Eq.== @ Plutus.V1.Ledger.Value.CurrencySymbol Plutus.V1.Ledger.Value.$fEqCurrencySymbol0 (case ds_d161z of { (cs [Occ=Once], _ [Occ=Dead]) -> cs }) (Main.vdThreadSymbol validatorData)) (PlutusTx.Eq.== @ GHC.Integer.Type.Integer PlutusTx.Eq.$fEqInteger (case ds_d161z of { (_ [Occ=Dead], am [Occ=Once]) -> am }) (-1)) }) Context: Compiling expr: let { txInfo :: Plutus.V1.Ledger.Contexts.TxInfo [LclId, Unf=Unf{Src=<vanilla>, TopLvl=False, Value=False, ConLike=False, WorkFree=False, Expandable=True, Guidance=IF_ARGS [] 20 0}] txInfo = Plutus.V1.Ledger.Contexts.scriptContextTxInfo ctx } in let { ds_d165Y :: (Plutus.V1.Ledger.Value.Value, GHC.Integer.Type.Integer) [LclId, Unf=Unf{Src=<vanilla>, TopLvl=False, Value=False, ConLike=False, WorkFree=False, Expandable=False, Guidance=NEVER}] ds_d165Y = join { fail_d165W [Occ=Once*!T[1]] :: GHC.Prim.Void# -> (Plutus.V1.Ledger.Value.Value, GHC.Integer.Type.Integer) [LclId[JoinId(1)], Arity=1, Str=<L,U>b, Unf=Unf{Src=<vanilla>, TopLvl=False, Value=True, ConLike=True, WorkFree=True, Expandable=True, Guidance=IF_ARGS [0] 200 0}] fail_d165W _ [Occ=Dead, OS=OneShot] = Control.Exception.Base.patError @ 'GHC.Types.LiftedRep @ (Plutus.V1.Ledger.Value.Value, GHC.Integer.Type.Integer) "/tmp/web-ghc-work-dcc9ed4f1ebc164d/Main.hs:(118,33)-(122,51)|case"# } in case Plutus.V1.Ledger.Contexts.getContinuingOutputs ctx of { [] -> jump fail_d165W GHC.Prim.void#; : o ds_d165V [Occ=Once!] -> case ds_d165V of { [] -> case Plutus.V1.Ledger.Tx.txOutDatum o of { GHC.Maybe.Nothing -> Control.Exception.Base.patError @ 'GHC.Types.LiftedRep @ (Plutus.V1.Ledger.Value.Value, GHC.Integer.Type.Integer) "/tmp/web-ghc-work-dcc9ed4f1ebc164d/Main.hs:(119,20)-(122,51)|case"#; GHC.Maybe.Just h [Occ=Once] -> case Plutus.V1.Ledger.Contexts.findDatum h txInfo of { GHC.Maybe.Nothing -> Control.Exception.Base.patError @ 'GHC.Types.LiftedRep @ (Plutus.V1.Ledger.Value.Value, GHC.Integer.Type.Integer) "/tmp/web-ghc-work-dcc9ed4f1ebc164d/Main.hs:(120,27)-(122,51)|case"#; GHC.Maybe.Just ds_d165g [Occ=Once] -> case PlutusTx.IsData.Class.fromBuiltinData @ GHC.Integer.Type.Integer PlutusTx.IsData.Class.$fFromDataInteger (ds_d165g `cast` (Plutus.V1.Ledger.Scripts.N:Datum[0] :: GHC.Types.Coercible Plutus.V1.Ledger.Scripts.Datum PlutusTx.Builtins.Internal.BuiltinData)) of { GHC.Maybe.Nothing -> Control.Exception.Base.patError @ 'GHC.Types.LiftedRep @ (Plutus.V1.Ledger.Value.Value, GHC.Integer.Type.Integer) "/tmp/web-ghc-work-dcc9ed4f1ebc164d/Main.hs:(121,38)-(122,51)|case"#; GHC.Maybe.Just c [Occ=Once] -> (Plutus.V1.Ledger.Tx.txOutValue o, c) } } }; : _ [Occ=Dead] _ [Occ=Dead] -> jump fail_d165W GHC.Prim.void# } } } in PlutusTx.Bool.&& (Ledger.Constraints.TxConstraints.isSatisfiable @ GHC.Types.Any @ GHC.Types.Any (Ledger.Constraints.TxConstraints.mustBeSignedBy @ GHC.Types.Any @ GHC.Types.Any (Main.vdOwner validatorData))) (case action of { Main.Mint -> PlutusTx.Bool.&& (PlutusTx.Bool.|| (PlutusTx.Builtins.lessThanInteger count (Main.vdMaxSupply validatorData)) (PlutusTx.Eq.== @ GHC.Integer.Type.Integer PlutusTx.Eq.$fEqInteger (Main.vdMaxSupply validatorData) (-1))) (let { ds_d15Zm :: (Plutus.V1.Ledger.Value.CurrencySymbol, GHC.Integer.Type.Integer) [LclId, Unf=Unf{Src=<vanilla>, TopLvl=False, Value=False, ConLike=False, WorkFree=False, Expandable=False, Guidance=IF_ARGS [] 298 30}] ds_d15Zm = join { fail_d161x [Occ=Once*!T[1]] :: GHC.Prim.Void# -> (Plutus.V1.Ledger.Value.CurrencySymbol, GHC.Integer.Type.Integer) [LclId[JoinId(1)], Arity=1, Str=<L,U>b, Unf=Unf{Src=<vanilla>, TopLvl=False, Value=True, ConLike=True, WorkFree=True, Expandable=True, Guidance=IF_ARGS [0] 200 0}] fail_d161x _ [Occ=Dead, OS=OneShot] = Control.Exception.Base.patError @ 'GHC.Types.LiftedRep @ (Plutus.V1.Ledger.Value.CurrencySymbol, GHC.Integer.Type.Integer) "/tmp/web-ghc-work-dcc9ed4f1ebc164d/Main.hs:105:27-61|[(cs, _, am)]"# } in case Plutus.V1.Ledger.Value.flattenValue (case ds_d165Y of { (outValue [Occ=Once], _ [Occ=Dead]) -> outValue }) of { [] -> jump fail_d161x GHC.Prim.void#; : ds_d161u [Occ=Once!] ds_d161v [Occ=Once!] -> case ds_d161u of { (cs [Occ=Once], _ [Occ=Dead], am [Occ=Once]) -> case ds_d161v of { [] -> (cs, am); : _ [Occ=Dead] _ [Occ=Dead] -> jump fail_d161x GHC.Prim.void# } } } } in PlutusTx.Bool.&& (PlutusTx.Eq.== @ Plutus.V1.Ledger.Value.CurrencySymbol Plutus.V1.Ledger.Value.$fEqCurrencySymbol0 (case ds_d15Zm of { (cs [Occ=Once], _ [Occ=Dead]) -> cs }) (Main.vdThreadSymbol validatorData)) (PlutusTx.Bool.&& (PlutusTx.Eq.== @ GHC.Integer.Type.Integer PlutusTx.Eq.$fEqInteger (case ds_d15Zm of { (_ [Occ=Dead], am [Occ=Once]) -> am }) 1) (PlutusTx.Eq.== @ GHC.Integer.Type.Integer PlutusTx.Eq.$fEqInteger (case ds_d165Y of { (_ [Occ=Dead], nextCount [Occ=Once]) -> nextCount }) (PlutusTx.Numeric.+ @ GHC.Integer.Type.Integer PlutusTx.Numeric.$fAdditiveSemigroupInteger count (PlutusTx.Foldable.length @ [] @ (Plutus.V1.Ledger.Value.CurrencySymbol, Plutus.V1.Ledger.Value.TokenName, GHC.Integer.Type.Integer) PlutusTx.Foldable.$fFoldable[] (Plutus.V1.Ledger.Value.flattenValue (Plutus.V1.Ledger.Contexts.txInfoMint txInfo))))))); Main.Burn -> let { ds_d161z :: (Plutus.V1.Ledger.Value.CurrencySymbol, GHC.Integer.Type.Integer) [LclId, Unf=Unf{Src=<vanilla>, TopLvl=False, Value=False, ConLike=False, WorkFree=False, Expandable=False, Guidance=IF_ARGS [] 308 30}] ds_d161z = join { fail_d163J [Occ=Once*!T[1]] :: GHC.Prim.Void# -> (Plutus.V1.Ledger.Value.CurrencySymbol, GHC.Integer.Type.Integer) [LclId[JoinId(1)], Arity=1, Str=<L,U>b, Unf=Unf{Src=<vanilla>, TopLvl=False, Value=True, ConLike=True, WorkFree=True, Expandable=True, Guidance=IF_ARGS [0] 200 0}] fail_d163J _ [Occ=Dead, OS=OneShot] = Control.Exception.Base.patError @ 'GHC.Types.LiftedRep @ (Plutus.V1.Ledger.Value.CurrencySymbol, GHC.Integer.Type.Integer) "/tmp/web-ghc-work-dcc9ed4f1ebc164d/Main.hs:108:25-49|[(cs, _, am)]"# } in case Plutus.V1.Ledger.Value.flattenValue (Plutus.V1.Ledger.Contexts.txInfoMint txInfo) of { [] -> jump fail_d163J GHC.Prim.void#; : ds_d163G [Occ=Once!] ds_d163H [Occ=Once!] -> case ds_d163G of { (cs [Occ=Once], _ [Occ=Dead], am [Occ=Once]) -> case ds_d163H of { [] -> (cs, am); : _ [Occ=Dead] _ [Occ=Dead] -> jump fail_d163J GHC.Prim.void# } } } } in PlutusTx.Bool.&& (PlutusTx.Eq.== @ Plutus.V1.Ledger.Value.CurrencySymbol Plutus.V1.Ledger.Value.$fEqCurrencySymbol0 (case ds_d161z of { (cs [Occ=Once], _ [Occ=Dead]) -> cs }) (Main.vdThreadSymbol validatorData)) (PlutusTx.Eq.== @ GHC.Integer.Type.Integer PlutusTx.Eq.$fEqInteger (case ds_d161z of { (_ [Occ=Dead], am [Occ=Once]) -> am }) (-1)) }) Context: Compiling expr: \ (ctx :: Plutus.V1.Ledger.Contexts.ScriptContext) -> let { txInfo :: Plutus.V1.Ledger.Contexts.TxInfo [LclId, Unf=Unf{Src=<vanilla>, TopLvl=False, Value=False, ConLike=False, WorkFree=False, Expandable=True, Guidance=IF_ARGS [] 20 0}] txInfo = Plutus.V1.Ledger.Contexts.scriptContextTxInfo ctx } in let { ds_d165Y :: (Plutus.V1.Ledger.Value.Value, GHC.Integer.Type.Integer) [LclId, Unf=Unf{Src=<vanilla>, TopLvl=False, Value=False, ConLike=False, WorkFree=False, Expandable=False, Guidance=NEVER}] ds_d165Y = join { fail_d165W [Occ=Once*!T[1]] :: GHC.Prim.Void# -> (Plutus.V1.Ledger.Value.Value, GHC.Integer.Type.Integer) [LclId[JoinId(1)], Arity=1, Str=<L,U>b, Unf=Unf{Src=<vanilla>, TopLvl=False, Value=True, ConLike=True, WorkFree=True, Expandable=True, Guidance=IF_ARGS [0] 200 0}] fail_d165W _ [Occ=Dead, OS=OneShot] = Control.Exception.Base.patError @ 'GHC.Types.LiftedRep @ (Plutus.V1.Ledger.Value.Value, GHC.Integer.Type.Integer) "/tmp/web-ghc-work-dcc9ed4f1ebc164d/Main.hs:(118,33)-(122,51)|case"# } in case Plutus.V1.Ledger.Contexts.getContinuingOutputs ctx of { [] -> jump fail_d165W GHC.Prim.void#; : o ds_d165V [Occ=Once!] -> case ds_d165V of { [] -> case Plutus.V1.Ledger.Tx.txOutDatum o of { GHC.Maybe.Nothing -> Control.Exception.Base.patError @ 'GHC.Types.LiftedRep @ (Plutus.V1.Ledger.Value.Value, GHC.Integer.Type.Integer) "/tmp/web-ghc-work-dcc9ed4f1ebc164d/Main.hs:(119,20)-(122,51)|case"#; GHC.Maybe.Just h [Occ=Once] -> case Plutus.V1.Ledger.Contexts.findDatum h txInfo of { GHC.Maybe.Nothing -> Control.Exception.Base.patError @ 'GHC.Types.LiftedRep @ (Plutus.V1.Ledger.Value.Value, GHC.Integer.Type.Integer) "/tmp/web-ghc-work-dcc9ed4f1ebc164d/Main.hs:(120,27)-(122,51)|case"#; GHC.Maybe.Just ds_d165g [Occ=Once] -> case PlutusTx.IsData.Class.fromBuiltinData @ GHC.Integer.Type.Integer PlutusTx.IsData.Class.$fFromDataInteger (ds_d165g `cast` (Plutus.V1.Ledger.Scripts.N:Datum[0] :: GHC.Types.Coercible Plutus.V1.Ledger.Scripts.Datum PlutusTx.Builtins.Internal.BuiltinData)) of { GHC.Maybe.Nothing -> Control.Exception.Base.patError @ 'GHC.Types.LiftedRep @ (Plutus.V1.Ledger.Value.Value, GHC.Integer.Type.Integer) "/tmp/web-ghc-work-dcc9ed4f1ebc164d/Main.hs:(121,38)-(122,51)|case"#; GHC.Maybe.Just c [Occ=Once] -> (Plutus.V1.Ledger.Tx.txOutValue o, c) } } }; : _ [Occ=Dead] _ [Occ=Dead] -> jump fail_d165W GHC.Prim.void# } } } in PlutusTx.Bool.&& (Ledger.Constraints.TxConstraints.isSatisfiable @ GHC.Types.Any @ GHC.Types.Any (Ledger.Constraints.TxConstraints.mustBeSignedBy @ GHC.Types.Any @ GHC.Types.Any (Main.vdOwner validatorData))) (case action of { Main.Mint -> PlutusTx.Bool.&& (PlutusTx.Bool.|| (PlutusTx.Builtins.lessThanInteger count (Main.vdMaxSupply validatorData)) (PlutusTx.Eq.== @ GHC.Integer.Type.Integer PlutusTx.Eq.$fEqInteger (Main.vdMaxSupply validatorData) (-1))) (let { ds_d15Zm :: (Plutus.V1.Ledger.Value.CurrencySymbol, GHC.Integer.Type.Integer) [LclId, Unf=Unf{Src=<vanilla>, TopLvl=False, Value=False, ConLike=False, WorkFree=False, Expandable=False, Guidance=IF_ARGS [] 298 30}] ds_d15Zm = join { fail_d161x [Occ=Once*!T[1]] :: GHC.Prim.Void# -> (Plutus.V1.Ledger.Value.CurrencySymbol, GHC.Integer.Type.Integer) [LclId[JoinId(1)], Arity=1, Str=<L,U>b, Unf=Unf{Src=<vanilla>, TopLvl=False, Value=True, ConLike=True, WorkFree=True, Expandable=True, Guidance=IF_ARGS [0] 200 0}] fail_d161x _ [Occ=Dead, OS=OneShot] = Control.Exception.Base.patError @ 'GHC.Types.LiftedRep @ (Plutus.V1.Ledger.Value.CurrencySymbol, GHC.Integer.Type.Integer) "/tmp/web-ghc-work-dcc9ed4f1ebc164d/Main.hs:105:27-61|[(cs, _, am)]"# } in case Plutus.V1.Ledger.Value.flattenValue (case ds_d165Y of { (outValue [Occ=Once], _ [Occ=Dead]) -> outValue }) of { [] -> jump fail_d161x GHC.Prim.void#; : ds_d161u [Occ=Once!] ds_d161v [Occ=Once!] -> case ds_d161u of { (cs [Occ=Once], _ [Occ=Dead], am [Occ=Once]) -> case ds_d161v of { [] -> (cs, am); : _ [Occ=Dead] _ [Occ=Dead] -> jump fail_d161x GHC.Prim.void# } } } } in PlutusTx.Bool.&& (PlutusTx.Eq.== @ Plutus.V1.Ledger.Value.CurrencySymbol Plutus.V1.Ledger.Value.$fEqCurrencySymbol0 (case ds_d15Zm of { (cs [Occ=Once], _ [Occ=Dead]) -> cs }) (Main.vdThreadSymbol validatorData)) (PlutusTx.Bool.&& (PlutusTx.Eq.== @ GHC.Integer.Type.Integer PlutusTx.Eq.$fEqInteger (case ds_d15Zm of { (_ [Occ=Dead], am [Occ=Once]) -> am }) 1) (PlutusTx.Eq.== @ GHC.Integer.Type.Integer PlutusTx.Eq.$fEqInteger (case ds_d165Y of { (_ [Occ=Dead], nextCount [Occ=Once]) -> nextCount }) (PlutusTx.Numeric.+ @ GHC.Integer.Type.Integer PlutusTx.Numeric.$fAdditiveSemigroupInteger count (PlutusTx.Foldable.length @ [] @ (Plutus.V1.Ledger.Value.CurrencySymbol, Plutus.V1.Ledger.Value.TokenName, GHC.Integer.Type.Integer) PlutusTx.Foldable.$fFoldable[] (Plutus.V1.Ledger.Value.flattenValue (Plutus.V1.Ledger.Contexts.txInfoMint txInfo))))))); Main.Burn -> let { ds_d161z :: (Plutus.V1.Ledger.Value.CurrencySymbol, GHC.Integer.Type.Integer) [LclId, Unf=Unf{Src=<vanilla>, TopLvl=False, Value=False, ConLike=False, WorkFree=False, Expandable=False, Guidance=IF_ARGS [] 308 30}] ds_d161z = join { fail_d163J [Occ=Once*!T[1]] :: GHC.Prim.Void# -> (Plutus.V1.Ledger.Value.CurrencySymbol, GHC.Integer.Type.Integer) [LclId[JoinId(1)], Arity=1, Str=<L,U>b, Unf=Unf{Src=<vanilla>, TopLvl=False, Value=True, ConLike=True, WorkFree=True, Expandable=True, Guidance=IF_ARGS [0] 200 0}] fail_d163J _ [Occ=Dead, OS=OneShot] = Control.Exception.Base.patError @ 'GHC.Types.LiftedRep @ (Plutus.V1.Ledger.Value.CurrencySymbol, GHC.Integer.Type.Integer) "/tmp/web-ghc-work-dcc9ed4f1ebc164d/Main.hs:108:25-49|[(cs, _, am)]"# } in case Plutus.V1.Ledger.Value.flattenValue (Plutus.V1.Ledger.Contexts.txInfoMint txInfo) of { [] -> jump fail_d163J GHC.Prim.void#; : ds_d163G [Occ=Once!] ds_d163H [Occ=Once!] -> case ds_d163G of { (cs [Occ=Once], _ [Occ=Dead], am [Occ=Once]) -> case ds_d163H of { [] -> (cs, am); : _ [Occ=Dead] _ [Occ=Dead] -> jump fail_d163J GHC.Prim.void# } } } } in PlutusTx.Bool.&& (PlutusTx.Eq.== @ Plutus.V1.Ledger.Value.CurrencySymbol Plutus.V1.Ledger.Value.$fEqCurrencySymbol0 (case ds_d161z of { (cs [Occ=Once], _ [Occ=Dead]) -> cs }) (Main.vdThreadSymbol validatorData)) (PlutusTx.Eq.== @ GHC.Integer.Type.Integer PlutusTx.Eq.$fEqInteger (case ds_d161z of { (_ [Occ=Dead], am [Occ=Once]) -> am }) (-1)) }) Context: Compiling expr: \ (action [Occ=Once!] :: Main.Action) (ctx :: Plutus.V1.Ledger.Contexts.ScriptContext) -> let { txInfo :: Plutus.V1.Ledger.Contexts.TxInfo [LclId, Unf=Unf{Src=<vanilla>, TopLvl=False, Value=False, ConLike=False, WorkFree=False, Expandable=True, Guidance=IF_ARGS [] 20 0}] txInfo = Plutus.V1.Ledger.Contexts.scriptContextTxInfo ctx } in let { ds_d165Y :: (Plutus.V1.Ledger.Value.Value, GHC.Integer.Type.Integer) [LclId, Unf=Unf{Src=<vanilla>, TopLvl=False, Value=False, ConLike=False, WorkFree=False, Expandable=False, Guidance=NEVER}] ds_d165Y = join { fail_d165W [Occ=Once*!T[1]] :: GHC.Prim.Void# -> (Plutus.V1.Ledger.Value.Value, GHC.Integer.Type.Integer) [LclId[JoinId(1)], Arity=1, Str=<L,U>b, Unf=Unf{Src=<vanilla>, TopLvl=False, Value=True, ConLike=True, WorkFree=True, Expandable=True, Guidance=IF_ARGS [0] 200 0}] fail_d165W _ [Occ=Dead, OS=OneShot] = Control.Exception.Base.patError @ 'GHC.Types.LiftedRep @ (Plutus.V1.Ledger.Value.Value, GHC.Integer.Type.Integer) "/tmp/web-ghc-work-dcc9ed4f1ebc164d/Main.hs:(118,33)-(122,51)|case"# } in case Plutus.V1.Ledger.Contexts.getContinuingOutputs ctx of { [] -> jump fail_d165W GHC.Prim.void#; : o ds_d165V [Occ=Once!] -> case ds_d165V of { [] -> case Plutus.V1.Ledger.Tx.txOutDatum o of { GHC.Maybe.Nothing -> Control.Exception.Base.patError @ 'GHC.Types.LiftedRep @ (Plutus.V1.Ledger.Value.Value, GHC.Integer.Type.Integer) "/tmp/web-ghc-work-dcc9ed4f1ebc164d/Main.hs:(119,20)-(122,51)|case"#; GHC.Maybe.Just h [Occ=Once] -> case Plutus.V1.Ledger.Contexts.findDatum h txInfo of { GHC.Maybe.Nothing -> Control.Exception.Base.patError @ 'GHC.Types.LiftedRep @ (Plutus.V1.Ledger.Value.Value, GHC.Integer.Type.Integer) "/tmp/web-ghc-work-dcc9ed4f1ebc164d/Main.hs:(120,27)-(122,51)|case"#; GHC.Maybe.Just ds_d165g [Occ=Once] -> case PlutusTx.IsData.Class.fromBuiltinData @ GHC.Integer.Type.Integer PlutusTx.IsData.Class.$fFromDataInteger (ds_d165g `cast` (Plutus.V1.Ledger.Scripts.N:Datum[0] :: GHC.Types.Coercible Plutus.V1.Ledger.Scripts.Datum PlutusTx.Builtins.Internal.BuiltinData)) of { GHC.Maybe.Nothing -> Control.Exception.Base.patError @ 'GHC.Types.LiftedRep @ (Plutus.V1.Ledger.Value.Value, GHC.Integer.Type.Integer) "/tmp/web-ghc-work-dcc9ed4f1ebc164d/Main.hs:(121,38)-(122,51)|case"#; GHC.Maybe.Just c [Occ=Once] -> (Plutus.V1.Ledger.Tx.txOutValue o, c) } } }; : _ [Occ=Dead] _ [Occ=Dead] -> jump fail_d165W GHC.Prim.void# } } } in PlutusTx.Bool.&& (Ledger.Constraints.TxConstraints.isSatisfiable @ GHC.Types.Any @ GHC.Types.Any (Ledger.Constraints.TxConstraints.mustBeSignedBy @ GHC.Types.Any @ GHC.Types.Any (Main.vdOwner validatorData))) (case action of { Main.Mint -> PlutusTx.Bool.&& (PlutusTx.Bool.|| (PlutusTx.Builtins.lessThanInteger count (Main.vdMaxSupply validatorData)) (PlutusTx.Eq.== @ GHC.Integer.Type.Integer PlutusTx.Eq.$fEqInteger (Main.vdMaxSupply validatorData) (-1))) (let { ds_d15Zm :: (Plutus.V1.Ledger.Value.CurrencySymbol, GHC.Integer.Type.Integer) [LclId, Unf=Unf{Src=<vanilla>, TopLvl=False, Value=False, ConLike=False, WorkFree=False, Expandable=False, Guidance=IF_ARGS [] 298 30}] ds_d15Zm = join { fail_d161x [Occ=Once*!T[1]] :: GHC.Prim.Void# -> (Plutus.V1.Ledger.Value.CurrencySymbol, GHC.Integer.Type.Integer) [LclId[JoinId(1)], Arity=1, Str=<L,U>b, Unf=Unf{Src=<vanilla>, TopLvl=False, Value=True, ConLike=True, WorkFree=True, Expandable=True, Guidance=IF_ARGS [0] 200 0}] fail_d161x _ [Occ=Dead, OS=OneShot] = Control.Exception.Base.patError @ 'GHC.Types.LiftedRep @ (Plutus.V1.Ledger.Value.CurrencySymbol, GHC.Integer.Type.Integer) "/tmp/web-ghc-work-dcc9ed4f1ebc164d/Main.hs:105:27-61|[(cs, _, am)]"# } in case Plutus.V1.Ledger.Value.flattenValue (case ds_d165Y of { (outValue [Occ=Once], _ [Occ=Dead]) -> outValue }) of { [] -> jump fail_d161x GHC.Prim.void#; : ds_d161u [Occ=Once!] ds_d161v [Occ=Once!] -> case ds_d161u of { (cs [Occ=Once], _ [Occ=Dead], am [Occ=Once]) -> case ds_d161v of { [] -> (cs, am); : _ [Occ=Dead] _ [Occ=Dead] -> jump fail_d161x GHC.Prim.void# } } } } in PlutusTx.Bool.&& (PlutusTx.Eq.== @ Plutus.V1.Ledger.Value.CurrencySymbol Plutus.V1.Ledger.Value.$fEqCurrencySymbol0 (case ds_d15Zm of { (cs [Occ=Once], _ [Occ=Dead]) -> cs }) (Main.vdThreadSymbol validatorData)) (PlutusTx.Bool.&& (PlutusTx.Eq.== @ GHC.Integer.Type.Integer PlutusTx.Eq.$fEqInteger (case ds_d15Zm of { (_ [Occ=Dead], am [Occ=Once]) -> am }) 1) (PlutusTx.Eq.== @ GHC.Integer.Type.Integer PlutusTx.Eq.$fEqInteger (case ds_d165Y of { (_ [Occ=Dead], nextCount [Occ=Once]) -> nextCount }) (PlutusTx.Numeric.+ @ GHC.Integer.Type.Integer PlutusTx.Numeric.$fAdditiveSemigroupInteger count (PlutusTx.Foldable.length @ [] @ (Plutus.V1.Ledger.Value.CurrencySymbol, Plutus.V1.Ledger.Value.TokenName, GHC.Integer.Type.Integer) PlutusTx.Foldable.$fFoldable[] (Plutus.V1.Ledger.Value.flattenValue (Plutus.V1.Ledger.Contexts.txInfoMint txInfo))))))); Main.Burn -> let { ds_d161z :: (Plutus.V1.Ledger.Value.CurrencySymbol, GHC.Integer.Type.Integer) [LclId, Unf=Unf{Src=<vanilla>, TopLvl=False, Value=False, ConLike=False, WorkFree=False, Expandable=False, Guidance=IF_ARGS [] 308 30}] ds_d161z = join { fail_d163J [Occ=Once*!T[1]] :: GHC.Prim.Void# -> (Plutus.V1.Ledger.Value.CurrencySymbol, GHC.Integer.Type.Integer) [LclId[JoinId(1)], Arity=1, Str=<L,U>b, Unf=Unf{Src=<vanilla>, TopLvl=False, Value=True, ConLike=True, WorkFree=True, Expandable=True, Guidance=IF_ARGS [0] 200 0}] fail_d163J _ [Occ=Dead, OS=OneShot] = Control.Exception.Base.patError @ 'GHC.Types.LiftedRep @ (Plutus.V1.Ledger.Value.CurrencySymbol, GHC.Integer.Type.Integer) "/tmp/web-ghc-work-dcc9ed4f1ebc164d/Main.hs:108:25-49|[(cs, _, am)]"# } in case Plutus.V1.Ledger.Value.flattenValue (Plutus.V1.Ledger.Contexts.txInfoMint txInfo) of { [] -> jump fail_d163J GHC.Prim.void#; : ds_d163G [Occ=Once!] ds_d163H [Occ=Once!] -> case ds_d163G of { (cs [Occ=Once], _ [Occ=Dead], am [Occ=Once]) -> case ds_d163H of { [] -> (cs, am); : _ [Occ=Dead] _ [Occ=Dead] -> jump fail_d163J GHC.Prim.void# } } } } in PlutusTx.Bool.&& (PlutusTx.Eq.== @ Plutus.V1.Ledger.Value.CurrencySymbol Plutus.V1.Ledger.Value.$fEqCurrencySymbol0 (case ds_d161z of { (cs [Occ=Once], _ [Occ=Dead]) -> cs }) (Main.vdThreadSymbol validatorData)) (PlutusTx.Eq.== @ GHC.Integer.Type.Integer PlutusTx.Eq.$fEqInteger (case ds_d161z of { (_ [Occ=Dead], am [Occ=Once]) -> am }) (-1)) }) Context: Compiling expr: \ (count :: GHC.Integer.Type.Integer) (action [Occ=Once!] :: Main.Action) (ctx :: Plutus.V1.Ledger.Contexts.ScriptContext) -> let { txInfo :: Plutus.V1.Ledger.Contexts.TxInfo [LclId, Unf=Unf{Src=<vanilla>, TopLvl=False, Value=False, ConLike=False, WorkFree=False, Expandable=True, Guidance=IF_ARGS [] 20 0}] txInfo = Plutus.V1.Ledger.Contexts.scriptContextTxInfo ctx } in let { ds_d165Y :: (Plutus.V1.Ledger.Value.Value, GHC.Integer.Type.Integer) [LclId, Unf=Unf{Src=<vanilla>, TopLvl=False, Value=False, ConLike=False, WorkFree=False, Expandable=False, Guidance=NEVER}] ds_d165Y = join { fail_d165W [Occ=Once*!T[1]] :: GHC.Prim.Void# -> (Plutus.V1.Ledger.Value.Value, GHC.Integer.Type.Integer) [LclId[JoinId(1)], Arity=1, Str=<L,U>b, Unf=Unf{Src=<vanilla>, TopLvl=False, Value=True, ConLike=True, WorkFree=True, Expandable=True, Guidance=IF_ARGS [0] 200 0}] fail_d165W _ [Occ=Dead, OS=OneShot] = Control.Exception.Base.patError @ 'GHC.Types.LiftedRep @ (Plutus.V1.Ledger.Value.Value, GHC.Integer.Type.Integer) "/tmp/web-ghc-work-dcc9ed4f1ebc164d/Main.hs:(118,33)-(122,51)|case"# } in case Plutus.V1.Ledger.Contexts.getContinuingOutputs ctx of { [] -> jump fail_d165W GHC.Prim.void#; : o ds_d165V [Occ=Once!] -> case ds_d165V of { [] -> case Plutus.V1.Ledger.Tx.txOutDatum o of { GHC.Maybe.Nothing -> Control.Exception.Base.patError @ 'GHC.Types.LiftedRep @ (Plutus.V1.Ledger.Value.Value, GHC.Integer.Type.Integer) "/tmp/web-ghc-work-dcc9ed4f1ebc164d/Main.hs:(119,20)-(122,51)|case"#; GHC.Maybe.Just h [Occ=Once] -> case Plutus.V1.Ledger.Contexts.findDatum h txInfo of { GHC.Maybe.Nothing -> Control.Exception.Base.patError @ 'GHC.Types.LiftedRep @ (Plutus.V1.Ledger.Value.Value, GHC.Integer.Type.Integer) "/tmp/web-ghc-work-dcc9ed4f1ebc164d/Main.hs:(120,27)-(122,51)|case"#; GHC.Maybe.Just ds_d165g [Occ=Once] -> case PlutusTx.IsData.Class.fromBuiltinData @ GHC.Integer.Type.Integer PlutusTx.IsData.Class.$fFromDataInteger (ds_d165g `cast` (Plutus.V1.Ledger.Scripts.N:Datum[0] :: GHC.Types.Coercible Plutus.V1.Ledger.Scripts.Datum PlutusTx.Builtins.Internal.BuiltinData)) of { GHC.Maybe.Nothing -> Control.Exception.Base.patError @ 'GHC.Types.LiftedRep @ (Plutus.V1.Ledger.Value.Value, GHC.Integer.Type.Integer) "/tmp/web-ghc-work-dcc9ed4f1ebc164d/Main.hs:(121,38)-(122,51)|case"#; GHC.Maybe.Just c [Occ=Once] -> (Plutus.V1.Ledger.Tx.txOutValue o, c) } } }; : _ [Occ=Dead] _ [Occ=Dead] -> jump fail_d165W GHC.Prim.void# } } } in PlutusTx.Bool.&& (Ledger.Constraints.TxConstraints.isSatisfiable @ GHC.Types.Any @ GHC.Types.Any (Ledger.Constraints.TxConstraints.mustBeSignedBy @ GHC.Types.Any @ GHC.Types.Any (Main.vdOwner validatorData))) (case action of { Main.Mint -> PlutusTx.Bool.&& (PlutusTx.Bool.|| (PlutusTx.Builtins.lessThanInteger count (Main.vdMaxSupply validatorData)) (PlutusTx.Eq.== @ GHC.Integer.Type.Integer PlutusTx.Eq.$fEqInteger (Main.vdMaxSupply validatorData) (-1))) (let { ds_d15Zm :: (Plutus.V1.Ledger.Value.CurrencySymbol, GHC.Integer.Type.Integer) [LclId, Unf=Unf{Src=<vanilla>, TopLvl=False, Value=False, ConLike=False, WorkFree=False, Expandable=False, Guidance=IF_ARGS [] 298 30}] ds_d15Zm = join { fail_d161x [Occ=Once*!T[1]] :: GHC.Prim.Void# -> (Plutus.V1.Ledger.Value.CurrencySymbol, GHC.Integer.Type.Integer) [LclId[JoinId(1)], Arity=1, Str=<L,U>b, Unf=Unf{Src=<vanilla>, TopLvl=False, Value=True, ConLike=True, WorkFree=True, Expandable=True, Guidance=IF_ARGS [0] 200 0}] fail_d161x _ [Occ=Dead, OS=OneShot] = Control.Exception.Base.patError @ 'GHC.Types.LiftedRep @ (Plutus.V1.Ledger.Value.CurrencySymbol, GHC.Integer.Type.Integer) "/tmp/web-ghc-work-dcc9ed4f1ebc164d/Main.hs:105:27-61|[(cs, _, am)]"# } in case Plutus.V1.Ledger.Value.flattenValue (case ds_d165Y of { (outValue [Occ=Once], _ [Occ=Dead]) -> outValue }) of { [] -> jump fail_d161x GHC.Prim.void#; : ds_d161u [Occ=Once!] ds_d161v [Occ=Once!] -> case ds_d161u of { (cs [Occ=Once], _ [Occ=Dead], am [Occ=Once]) -> case ds_d161v of { [] -> (cs, am); : _ [Occ=Dead] _ [Occ=Dead] -> jump fail_d161x GHC.Prim.void# } } } } in PlutusTx.Bool.&& (PlutusTx.Eq.== @ Plutus.V1.Ledger.Value.CurrencySymbol Plutus.V1.Ledger.Value.$fEqCurrencySymbol0 (case ds_d15Zm of { (cs [Occ=Once], _ [Occ=Dead]) -> cs }) (Main.vdThreadSymbol validatorData)) (PlutusTx.Bool.&& (PlutusTx.Eq.== @ GHC.Integer.Type.Integer PlutusTx.Eq.$fEqInteger (case ds_d15Zm of { (_ [Occ=Dead], am [Occ=Once]) -> am }) 1) (PlutusTx.Eq.== @ GHC.Integer.Type.Integer PlutusTx.Eq.$fEqInteger (case ds_d165Y of { (_ [Occ=Dead], nextCount [Occ=Once]) -> nextCount }) (PlutusTx.Numeric.+ @ GHC.Integer.Type.Integer PlutusTx.Numeric.$fAdditiveSemigroupInteger count (PlutusTx.Foldable.length @ [] @ (Plutus.V1.Ledger.Value.CurrencySymbol, Plutus.V1.Ledger.Value.TokenName, GHC.Integer.Type.Integer) PlutusTx.Foldable.$fFoldable[] (Plutus.V1.Ledger.Value.flattenValue (Plutus.V1.Ledger.Contexts.txInfoMint txInfo))))))); Main.Burn -> let { ds_d161z :: (Plutus.V1.Ledger.Value.CurrencySymbol, GHC.Integer.Type.Integer) [LclId, Unf=Unf{Src=<vanilla>, TopLvl=False, Value=False, ConLike=False, WorkFree=False, Expandable=False, Guidance=IF_ARGS [] 308 30}] ds_d161z = join { fail_d163J [Occ=Once*!T[1]] :: GHC.Prim.Void# -> (Plutus.V1.Ledger.Value.CurrencySymbol, GHC.Integer.Type.Integer) [LclId[JoinId(1)], Arity=1, Str=<L,U>b, Unf=Unf{Src=<vanilla>, TopLvl=False, Value=True, ConLike=True, WorkFree=True, Expandable=True, Guidance=IF_ARGS [0] 200 0}] fail_d163J _ [Occ=Dead, OS=OneShot] = Control.Exception.Base.patError @ 'GHC.Types.LiftedRep @ (Plutus.V1.Ledger.Value.CurrencySymbol, GHC.Integer.Type.Integer) "/tmp/web-ghc-work-dcc9ed4f1ebc164d/Main.hs:108:25-49|[(cs, _, am)]"# } in case Plutus.V1.Ledger.Value.flattenValue (Plutus.V1.Ledger.Contexts.txInfoMint txInfo) of { [] -> jump fail_d163J GHC.Prim.void#; : ds_d163G [Occ=Once!] ds_d163H [Occ=Once!] -> case ds_d163G of { (cs [Occ=Once], _ [Occ=Dead], am [Occ=Once]) -> case ds_d163H of { [] -> (cs, am); : _ [Occ=Dead] _ [Occ=Dead] -> jump fail_d163J GHC.Prim.void# } } } } in PlutusTx.Bool.&& (PlutusTx.Eq.== @ Plutus.V1.Ledger.Value.CurrencySymbol Plutus.V1.Ledger.Value.$fEqCurrencySymbol0 (case ds_d161z of { (cs [Occ=Once], _ [Occ=Dead]) -> cs }) (Main.vdThreadSymbol validatorData)) (PlutusTx.Eq.== @ GHC.Integer.Type.Integer PlutusTx.Eq.$fEqInteger (case ds_d161z of { (_ [Occ=Dead], am [Occ=Once]) -> am }) (-1)) }) Context: Compiling expr: \ (validatorData :: Main.ValidatorData) (count :: GHC.Integer.Type.Integer) (action [Occ=Once!] :: Main.Action) (ctx :: Plutus.V1.Ledger.Contexts.ScriptContext) -> let { txInfo :: Plutus.V1.Ledger.Contexts.TxInfo [LclId, Unf=Unf{Src=<vanilla>, TopLvl=False, Value=False, ConLike=False, WorkFree=False, Expandable=True, Guidance=IF_ARGS [] 20 0}] txInfo = Plutus.V1.Ledger.Contexts.scriptContextTxInfo ctx } in let { ds_d165Y :: (Plutus.V1.Ledger.Value.Value, GHC.Integer.Type.Integer) [LclId, Unf=Unf{Src=<vanilla>, TopLvl=False, Value=False, ConLike=False, WorkFree=False, Expandable=False, Guidance=NEVER}] ds_d165Y = join { fail_d165W [Occ=Once*!T[1]] :: GHC.Prim.Void# -> (Plutus.V1.Ledger.Value.Value, GHC.Integer.Type.Integer) [LclId[JoinId(1)], Arity=1, Str=<L,U>b, Unf=Unf{Src=<vanilla>, TopLvl=False, Value=True, ConLike=True, WorkFree=True, Expandable=True, Guidance=IF_ARGS [0] 200 0}] fail_d165W _ [Occ=Dead, OS=OneShot] = Control.Exception.Base.patError @ 'GHC.Types.LiftedRep @ (Plutus.V1.Ledger.Value.Value, GHC.Integer.Type.Integer) "/tmp/web-ghc-work-dcc9ed4f1ebc164d/Main.hs:(118,33)-(122,51)|case"# } in case Plutus.V1.Ledger.Contexts.getContinuingOutputs ctx of { [] -> jump fail_d165W GHC.Prim.void#; : o ds_d165V [Occ=Once!] -> case ds_d165V of { [] -> case Plutus.V1.Ledger.Tx.txOutDatum o of { GHC.Maybe.Nothing -> Control.Exception.Base.patError @ 'GHC.Types.LiftedRep @ (Plutus.V1.Ledger.Value.Value, GHC.Integer.Type.Integer) "/tmp/web-ghc-work-dcc9ed4f1ebc164d/Main.hs:(119,20)-(122,51)|case"#; GHC.Maybe.Just h [Occ=Once] -> case Plutus.V1.Ledger.Contexts.findDatum h txInfo of { GHC.Maybe.Nothing -> Control.Exception.Base.patError @ 'GHC.Types.LiftedRep @ (Plutus.V1.Ledger.Value.Value, GHC.Integer.Type.Integer) "/tmp/web-ghc-work-dcc9ed4f1ebc164d/Main.hs:(120,27)-(122,51)|case"#; GHC.Maybe.Just ds_d165g [Occ=Once] -> case PlutusTx.IsData.Class.fromBuiltinData @ GHC.Integer.Type.Integer PlutusTx.IsData.Class.$fFromDataInteger (ds_d165g `cast` (Plutus.V1.Ledger.Scripts.N:Datum[0] :: GHC.Types.Coercible Plutus.V1.Ledger.Scripts.Datum PlutusTx.Builtins.Internal.BuiltinData)) of { GHC.Maybe.Nothing -> Control.Exception.Base.patError @ 'GHC.Types.LiftedRep @ (Plutus.V1.Ledger.Value.Value, GHC.Integer.Type.Integer) "/tmp/web-ghc-work-dcc9ed4f1ebc164d/Main.hs:(121,38)-(122,51)|case"#; GHC.Maybe.Just c [Occ=Once] -> (Plutus.V1.Ledger.Tx.txOutValue o, c) } } }; : _ [Occ=Dead] _ [Occ=Dead] -> jump fail_d165W GHC.Prim.void# } } } in PlutusTx.Bool.&& (Ledger.Constraints.TxConstraints.isSatisfiable @ GHC.Types.Any @ GHC.Types.Any (Ledger.Constraints.TxConstraints.mustBeSignedBy @ GHC.Types.Any @ GHC.Types.Any (Main.vdOwner validatorData))) (case action of { Main.Mint -> PlutusTx.Bool.&& (PlutusTx.Bool.|| (PlutusTx.Builtins.lessThanInteger count (Main.vdMaxSupply validatorData)) (PlutusTx.Eq.== @ GHC.Integer.Type.Integer PlutusTx.Eq.$fEqInteger (Main.vdMaxSupply validatorData) (-1))) (let { ds_d15Zm :: (Plutus.V1.Ledger.Value.CurrencySymbol, GHC.Integer.Type.Integer) [LclId, Unf=Unf{Src=<vanilla>, TopLvl=False, Value=False, ConLike=False, WorkFree=False, Expandable=False, Guidance=IF_ARGS [] 298 30}] ds_d15Zm = join { fail_d161x [Occ=Once*!T[1]] :: GHC.Prim.Void# -> (Plutus.V1.Ledger.Value.CurrencySymbol, GHC.Integer.Type.Integer) [LclId[JoinId(1)], Arity=1, Str=<L,U>b, Unf=Unf{Src=<vanilla>, TopLvl=False, Value=True, ConLike=True, WorkFree=True, Expandable=True, Guidance=IF_ARGS [0] 200 0}] fail_d161x _ [Occ=Dead, OS=OneShot] = Control.Exception.Base.patError @ 'GHC.Types.LiftedRep @ (Plutus.V1.Ledger.Value.CurrencySymbol, GHC.Integer.Type.Integer) "/tmp/web-ghc-work-dcc9ed4f1ebc164d/Main.hs:105:27-61|[(cs, _, am)]"# } in case Plutus.V1.Ledger.Value.flattenValue (case ds_d165Y of { (outValue [Occ=Once], _ [Occ=Dead]) -> outValue }) of { [] -> jump fail_d161x GHC.Prim.void#; : ds_d161u [Occ=Once!] ds_d161v [Occ=Once!] -> case ds_d161u of { (cs [Occ=Once], _ [Occ=Dead], am [Occ=Once]) -> case ds_d161v of { [] -> (cs, am); : _ [Occ=Dead] _ [Occ=Dead] -> jump fail_d161x GHC.Prim.void# } } } } in PlutusTx.Bool.&& (PlutusTx.Eq.== @ Plutus.V1.Ledger.Value.CurrencySymbol Plutus.V1.Ledger.Value.$fEqCurrencySymbol0 (case ds_d15Zm of { (cs [Occ=Once], _ [Occ=Dead]) -> cs }) (Main.vdThreadSymbol validatorData)) (PlutusTx.Bool.&& (PlutusTx.Eq.== @ GHC.Integer.Type.Integer PlutusTx.Eq.$fEqInteger (case ds_d15Zm of { (_ [Occ=Dead], am [Occ=Once]) -> am }) 1) (PlutusTx.Eq.== @ GHC.Integer.Type.Integer PlutusTx.Eq.$fEqInteger (case ds_d165Y of { (_ [Occ=Dead], nextCount [Occ=Once]) -> nextCount }) (PlutusTx.Numeric.+ @ GHC.Integer.Type.Integer PlutusTx.Numeric.$fAdditiveSemigroupInteger count (PlutusTx.Foldable.length @ [] @ (Plutus.V1.Ledger.Value.CurrencySymbol, Plutus.V1.Ledger.Value.TokenName, GHC.Integer.Type.Integer) PlutusTx.Foldable.$fFoldable[] (Plutus.V1.Ledger.Value.flattenValue (Plutus.V1.Ledger.Contexts.txInfoMint txInfo))))))); Main.Burn -> let { ds_d161z :: (Plutus.V1.Ledger.Value.CurrencySymbol, GHC.Integer.Type.Integer) [LclId, Unf=Unf{Src=<vanilla>, TopLvl=False, Value=False, ConLike=False, WorkFree=False, Expandable=False, Guidance=IF_ARGS [] 308 30}] ds_d161z = join { fail_d163J [Occ=Once*!T[1]] :: GHC.Prim.Void# -> (Plutus.V1.Ledger.Value.CurrencySymbol, GHC.Integer.Type.Integer) [LclId[JoinId(1)], Arity=1, Str=<L,U>b, Unf=Unf{Src=<vanilla>, TopLvl=False, Value=True, ConLike=True, WorkFree=True, Expandable=True, Guidance=IF_ARGS [0] 200 0}] fail_d163J _ [Occ=Dead, OS=OneShot] = Control.Exception.Base.patError @ 'GHC.Types.LiftedRep @ (Plutus.V1.Ledger.Value.CurrencySymbol, GHC.Integer.Type.Integer) "/tmp/web-ghc-work-dcc9ed4f1ebc164d/Main.hs:108:25-49|[(cs, _, am)]"# } in case Plutus.V1.Ledger.Value.flattenValue (Plutus.V1.Ledger.Contexts.txInfoMint txInfo) of { [] -> jump fail_d163J GHC.Prim.void#; : ds_d163G [Occ=Once!] ds_d163H [Occ=Once!] -> case ds_d163G of { (cs [Occ=Once], _ [Occ=Dead], am [Occ=Once]) -> case ds_d163H of { [] -> (cs, am); : _ [Occ=Dead] _ [Occ=Dead] -> jump fail_d163J GHC.Prim.void# } } } } in PlutusTx.Bool.&& (PlutusTx.Eq.== @ Plutus.V1.Ledger.Value.CurrencySymbol Plutus.V1.Ledger.Value.$fEqCurrencySymbol0 (case ds_d161z of { (cs [Occ=Once], _ [Occ=Dead]) -> cs }) (Main.vdThreadSymbol validatorData)) (PlutusTx.Eq.== @ GHC.Integer.Type.Integer PlutusTx.Eq.$fEqInteger (case ds_d161z of { (_ [Occ=Dead], am [Occ=Once]) -> am }) (-1)) }) Context: Compiling definition of: Main.mkTokenValidator Context: Compiling expr: Main.mkTokenValidator Context: Compiling expr at "main:Main:(154,9)-(154,50)"
```
Not sure how to debug this yet. Any help and feedback is appreciated :smile: 